### PR TITLE
I have improved the Amazon::Ecs::Response to be able to Marshal.dump and Marshal.load

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -123,6 +123,7 @@ module Amazon
     class Response
       # XML input is in string format
       def initialize(xml)
+        @xml = xml # for serialize
         @doc = Hpricot(xml)
       end
 
@@ -186,6 +187,14 @@ module Amazon
           @total_pages = (@doc/"totalpages").inner_html.to_i
         end
         @total_pages
+      end
+
+      def marshal_dump
+        @xml
+      end
+
+      def marshal_load(xml)
+        initialize(xml)
       end
     end
     

--- a/test/amazon/ecs_test.rb
+++ b/test/amazon/ecs_test.rb
@@ -160,4 +160,9 @@ class Amazon::EcsTest < Test::Unit::TestCase
     resp = Amazon::Ecs.item_search("パソコン")
     assert(resp.is_valid_request?)
   end
+
+  def test_marshal_dump_request
+    resp = Amazon::Ecs::Response.new('<?xml version="1.0"?>')
+    assert_equal Marshal.load(Marshal.dump(resp)).doc.to_s, resp.doc.to_s
+  end
 end


### PR DESCRIPTION
I want to serialize Amazon::Ecs::Response objects.
So, I have improved the Amazon::Ecs::Response to be able to Marshal.dump and Marshal.load.
Please pull if you like.
