### PR TITLE
Update services

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -235,6 +235,8 @@ module Amazon
         unless secret_key.nil?
           request_to_sign="GET\n#{request_host}\n/onca/xml\n#{qs}"
           signature = "&Signature=#{sign_request(request_to_sign, secret_key)}"
+        else
+          raise Amazon::RequestError, "Must provide aWS_secret_key to sign request"
         end
 
         "#{request_url}#{qs}#{signature}"


### PR DESCRIPTION
Updated to latest URLs and improved security by not sending request unless request is signed, else potentially passing the aWS_secret_key (if aWS_secret_key is provided by mistake as a string key instead of symbol key)
