### PR TITLE
Updating rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rubygems/package_task'
 require 'rake/packagetask'
 
 desc "Create the RDOC html files"
-rd = Rake::RDocTask.new("rdoc") { |rdoc|
+rd = RDoc::Task.new { |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = "amazon-ecs"
   rdoc.options << '--line-numbers' << '--inline-source' << '--main' << 'Readme.rdoc'


### PR DESCRIPTION
I have modified those, because some class is no longer supported.

```
$ bundle exec rake -T
aborted!
ERROR: 'rake/rdoctask' is obsolete and no longer supported. Use 'rdoc/task' (available in RDoc 2.4.2+) instead.
```

and 

```
$ bundle exec rake -T

rake aborted!
ERROR: 'rake/gempackagetask' is obsolete and no longer supported. Use 'rubygems/packagetask' instead.
```
