### PR TITLE
using a url of rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'http://rubygems.org'
 
 gem 'nokogiri', '~> 1.4'
 gem 'ruby-hmac', '~> 0.3'


### PR DESCRIPTION
There is deprecated setting.

```
The source :rubygems is deprecated because HTTP requests are insecure.
```
