### PR TITLE
Remove deprecated call to Digest::Digest to remove Ruby 2.1 warnings

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -49,7 +49,7 @@ module Amazon
     OPENSSL_DIGEST_SUPPORT = OpenSSL::Digest.constants.include?( 'SHA256' ) ||
                              OpenSSL::Digest.constants.include?( :SHA256 )
     
-    OPENSSL_DIGEST = OpenSSL::Digest::Digest.new( 'sha256' ) if OPENSSL_DIGEST_SUPPORT
+    OPENSSL_DIGEST = OpenSSL::Digest.new( 'sha256' ) if OPENSSL_DIGEST_SUPPORT
     
     @@options = {
       :version => "2011-08-01",


### PR DESCRIPTION
In Ruby 2.1, OpenSSL::Digest::Digest is deprecated in favor of OpenSSL::Digest.

See: http://stackoverflow.com/questions/21184960/ruby-digestdigest-is-deprecated-use-digest
