### PR TITLE
Make the options setter append the options instead of replacing them

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -65,7 +65,7 @@ module Amazon
     
     # Set default search options
     def self.options=(opts)
-      @@options = opts
+      @@options.merge!(opts)
     end
     
     # Get debug flag.


### PR DESCRIPTION
Might fix issue #26 and issue #39

Certain Amazon Product APIs such as es, it or cn require that the options include

``` ruby
:service => "AWSECommerceService"
```

in the query. These options are set by default on `Amazon::Ec2.options`, but configuring the gem like

``` ruby
Amazon::Ecs.options = {
  :associate_tag => '[your associate tag]',
  :AWS_access_key_id => '[your developer token]',       
  :AWS_secret_key => '[your secret access key]'
}
```

overrides them. With this fix, the options now are merged with the ones previously set. Another maybe cleaner way to go would be to separate the `defaults` into a separate variable and manually merge them before each request.
