### PR TITLE
Adding link for India to SERVICE_URLS

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -43,7 +43,8 @@ module Amazon
         :fr => 'http://ecs.amazonaws.fr/onca/xml',
         :it => 'http://webservices.amazon.it/onca/xml',
         :cn => 'http://webservices.amazon.cn/onca/xml',
-        :es => 'http://webservices.amazon.es/onca/xml'
+        :es => 'http://webservices.amazon.es/onca/xml',
+        :in => 'http://webservices.amazon.in/onca/xml'
     }
 
     OPENSSL_DIGEST_SUPPORT = OpenSSL::Digest.constants.include?( 'SHA256' ) ||


### PR DESCRIPTION
First of all thank you for a great gem.

While trying to use the gem for amazon.in, I noticed that the SERVICE_URLS hash did not include the URL for India. I have added ":in => 'http://webservices.amazon.in/onca/xml'" to the hash.