### PR TITLE
make get_hash recursive

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -352,7 +352,6 @@ module Amazon
           else
             hash = {}
             result.children.each do |child|
-              # binding.pry
               hash[child.name] = self.get_hash(element, child.path)
             end
             hash

--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -347,12 +347,16 @@ module Amazon
 
         result = element.at_xpath(path)
         if result
-          hash = {}
-          result = result.children
-          result.each do |item|
-            hash[item.name] = item.inner_html
+          if result.children.size == 1 && result.children.first.name == "text"
+            result.children.first.inner_text
+          else
+            hash = {}
+            result.children.each do |child|
+              # binding.pry
+              hash[child.name] = self.get_hash(element, child.path)
+            end
+            hash
           end
-          hash
         end
       end
     end


### PR DESCRIPTION
Previously `get_hash` only hash-ified the top level element and called `inner_html` on its children. This change makes all child elements hashes too.