### PR TITLE
Include error response body into Amazon::RequestError when got error response

### DIFF
--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -137,11 +137,13 @@ module Amazon
       log "Request URL: #{request_url}"
 
       res = Net::HTTP.get_response(URI::parse(request_url))
-      body = Response.new(res.body)
+      ecs_res = Response.new(res.body)
       unless res.kind_of? Net::HTTPSuccess
-        raise Amazon::RequestError, "HTTP Response: #{res.code} #{res.message}#{ body.error}"
+        err_msg = "HTTP Response: #{res.code} #{res.message}"
+        err_msg += " - #{ecs_res.error}" if ecs_res.error
+        raise Amazon::RequestError, err_msg
       end
-      body
+      ecs_res
     end
 
     def self.validate_request(opts)

--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -137,10 +137,11 @@ module Amazon
       log "Request URL: #{request_url}"
 
       res = Net::HTTP.get_response(URI::parse(request_url))
+      body = Response.new(res.body)
       unless res.kind_of? Net::HTTPSuccess
-        raise Amazon::RequestError, "HTTP Response: #{res.code} #{res.message}"
+        raise Amazon::RequestError, "HTTP Response: #{res.code} #{res.message}#{ body.error}"
       end
-      Response.new(res.body)
+      body
     end
 
     def self.validate_request(opts)


### PR DESCRIPTION
When I got error response from Amazon, I would want to know the reason detail.

In this case, I set `Amazon::Ecs.debug = true` and open url of `Request URL:` output. However If include that data into `Amazon::RequestError`, it is more easy to understand.