### PR TITLE
More ruby versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
- - 2.0
  - 2.1
  - 2.2
- - 2.3
- - 2.4
+ - 2.3.3
+ - 2.4.0
 script: rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
 rvm:
+ - 2.0
+ - 2.1
  - 2.2
+ - 2.3
+ - 2.4
 script: rake test


### PR DESCRIPTION
Follow up to #57 

**[Update]**

Not sure why error occurs: `AWS_ACCESS_KEY_ID env variable is not set (RuntimeError)` .

Is env variable missing??