### PR TITLE
Update hmac

### DIFF
--- a/amazon-ecs.gemspec
+++ b/amazon-ecs.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |gem|
     gem.specification_version = 2
  
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      gem.add_runtime_dependency("nokogiri", "~> 1.4")
-      gem.add_runtime_dependency("ruby-hmac", "~> 0.3")
+      gem.add_runtime_dependency("nokogiri", "~> 1.9")
+      gem.add_runtime_dependency("ruby-hmac", "~> 0.4")
     else
       gem.add_dependency("nokogiri", "~> 1.4")
       gem.add_dependency("ruby-hmac", "~> 0.3")

--- a/amazon-ecs.gemspec
+++ b/amazon-ecs.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
  
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
       gem.add_runtime_dependency("nokogiri", "~> 1.9")
-      gem.add_runtime_dependency("ruby-hmac", "~> 0.4")
     else
       gem.add_dependency("nokogiri", "~> 1.4")
       gem.add_dependency("ruby-hmac", "~> 0.3")

--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -32,7 +32,7 @@ module Amazon
   class RequestError < StandardError; end
 
   class Ecs
-    VERSION = '2.5.1'
+    VERSION = '2.5.2'
 
     SERVICE_URLS = {
         :us => 'http://webservices.amazon.com/onca/xml',

--- a/lib/amazon/ecs.rb
+++ b/lib/amazon/ecs.rb
@@ -309,15 +309,7 @@ module Amazon
 
       def self.sign_request(url, key)
         return nil if key.nil?
-
-        if OPENSSL_DIGEST_SUPPORT
-          signature = OpenSSL::HMAC.digest(OPENSSL_DIGEST, key, url)
-          signature = [signature].pack('m').chomp
-        else
-          signature = Base64.encode64(HMAC::SHA256.digest(key, url)).strip
-        end
-        signature = CGI.escape(signature)
-        return signature
+        return CGI.escape(Base64.strict_encode64(OpenSSL::HMAC.digest("SHA256", key, url)))
       end
   end
 

--- a/test/amazon/ecs_test.rb
+++ b/test/amazon/ecs_test.rb
@@ -182,11 +182,11 @@ class Amazon::EcsTest < Test::Unit::TestCase
   end
 
   def test_browse_node_lookup
-    resp = Amazon::Ecs.browse_node_lookup("17")
+    resp = Amazon::Ecs.browse_node_lookup('17')
     assert resp.is_valid_request?, "Not a valid request"
 
     items = resp.get_elements("BrowseNode")
-    assert_equal 24, items.size
+    assert_equal 23, items.size
   end
 
   def test_similarity_lookup
@@ -194,12 +194,14 @@ class Amazon::EcsTest < Test::Unit::TestCase
     assert resp.is_valid_request?, "Not a valid request"
 
     items = resp.get_elements("Item")
-    assert_equal 10, items.size
+    assert_equal 7, items.size
   end
 
   def test_other_service_urls
+    test_regions = ENV['AWS_REGIONS'].split.collect(&:to_sym) || Amazon::Ecs::SERVICE_URLS.keys
+
     Amazon::Ecs::SERVICE_URLS.each do |key, value|
-      next if key == :us
+      next unless test_regions.include?(key)
 
       begin
         throttle_request


### PR DESCRIPTION
I updated the gem dependencies for Nokogiri and Ruby-HMAC.

I've also made a branch removing ruby-hmac which I can integrate into this or I can create a separate pull request. 

Some of the values in the test results seems to have changed, so I updated 24 browseNodes -> 23, 10 items -> 7 items. I also updated the service region test to allow setting env variable with supported regions.

Let me know what you think.